### PR TITLE
move bookmark patches to russian.ldf

### DIFF
--- a/russianb.dtx
+++ b/russianb.dtx
@@ -1363,12 +1363,15 @@ and the derived files             russianb.ins,
 %    which indicates explicitly breakpoint for hyphenation in a word. Meaning
 %    of these shorthands is explained in table~\ref{tab:russian-quote}.
 %
+%    Some of this definitions need a alternative definitions for the booksmarks.
 %    \begin{macrocode}
+\providecommand\texorpdfstring[2]{#1}
 \declare@shorthand{russian}{""}{\hskip\z@skip}
-\declare@shorthand{russian}{"~}{\textormath{\leavevmode\hbox{-}}{-}}
+\declare@shorthand{russian}{"~}{\texorpdfstring{\textormath{\leavevmode\hbox{-}}{-}}{-}}
 \declare@shorthand{russian}{"=}{\nobreak-\hskip\z@skip}
 \declare@shorthand{russian}{"|}{%
-  \textormath{\nobreak\discretionary{-}{}{\kern.03em}\allowhyphens}{}}
+  \texorpdfstring{%
+   \textormath{\nobreak\discretionary{-}{}{\kern.03em}\allowhyphens}{}}{}}
 %    \end{macrocode}
 %
 %    \subsubsection{Emdash, endash and hyphenation sign}
@@ -1380,10 +1383,10 @@ and the derived files             russianb.ins,
 %    its meaning to |\russian@sh@next| and finally call for |\russian@sh@tmp|.
 %    \begin{macrocode}
 \declare@shorthand{russian}{"-}{%
-  \def\russian@sh@tmp{%
+  \texorpdfstring{\def\russian@sh@tmp{%
     \if\russian@sh@next-\expandafter\russian@sh@emdash
     \else\expandafter\russian@sh@hyphen\fi}%
-  \futurelet\russian@sh@next\russian@sh@tmp}
+  \futurelet\russian@sh@next\russian@sh@tmp}{-}}
 %    \end{macrocode}
 %    Two macros |\russian@sh@hyphen| and |\russian@sh@emdash| called by
 %    |\russian@sh@tmp|  are defined below. The second of


### PR DESCRIPTION
I have removed now the patches for russian.ldf in hyperref.  A new hyperref will be upload probably in 1-2 week then the change will take effect. 

The effect of these changes can be tested by running this document:

~~~~
\documentclass{article}
\usepackage[russian]{babel}

\usepackage{hyperref}
\makeatletter
\def\HyPsd@babel@russian{}%
\def\HyPsd@RussianPatch{}

\makeatother
\begin{document}

a"|b  a"~b

a"-b a"--~b  a"--*b a"---b

\section{a"|b, a"~b}

\section{a"-b a"--~b  a"--*b a"---b}
\end{document}
~~~~

This produces a number of warnings from hyperref, and also broken bookmarks:

![image](https://user-images.githubusercontent.com/4047173/95605785-bb8ed800-0a59-11eb-9faf-0731e82ec027.png)

The pull request tries to repair this by moving the necessary code to russian.ldf.  The effect of this changes should be like the result of the following document. The output of the `"-` and similar commands is not perfect, but the original code in hyperref is not better: the shorthand is not expandable so not more can be done. 

~~~~
\documentclass{article}
\usepackage[russian]{babel}

\usepackage{hyperref}
\makeatletter
\def\HyPsd@babel@russian{}%
\def\HyPsd@RussianPatch{}

\makeatother
\begin{document}

\makeatletter
\declare@shorthand{russian}{"~}{\texorpdfstring{\textormath{\leavevmode\hbox{-}}{-}}{-}}
\declare@shorthand{russian}{"|}{%
  \texorpdfstring{\textormath{\nobreak\discretionary{-}{}{\kern.03em}\allowhyphens}{}}{}}
\declare@shorthand{russian}{"-}{%
  \texorpdfstring{%
  \def\russian@sh@tmp{%
    \if\russian@sh@next-\expandafter\russian@sh@emdash
    \else\expandafter\russian@sh@hyphen\fi}%
  \futurelet\russian@sh@next\russian@sh@tmp}{-}}
\makeatother


a"|b  a"~b

a"-b a"--~b  a"--*b a"---b

\section{a"|b, a"~b}

\section{a"-b a"--~b  a"--*b a"---b}
\end{document}
~~~~

![image](https://user-images.githubusercontent.com/4047173/95606001-04df2780-0a5a-11eb-82d6-f4b09f7918c0.png)

